### PR TITLE
Search filters advocates correctly

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,25 +17,26 @@ export default function Home() {
   }, []);
 
   const onChange = (e) => {
-    const searchTerm = e.target.value;
-
+    const searchTerm = e.target.value.toLowerCase();
+  
     document.getElementById("search-term").innerHTML = searchTerm;
-
+  
     console.log("filtering advocates...");
     const filteredAdvocates = advocates.filter((advocate) => {
       return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
+        advocate.firstName.toLowerCase().includes(searchTerm) ||
+        advocate.lastName.toLowerCase().includes(searchTerm) ||
+        advocate.city.toLowerCase().includes(searchTerm) ||
+        advocate.degree.toLowerCase().includes(searchTerm) ||
+        advocate.specialties.some((spec) =>
+          spec.toLowerCase().includes(searchTerm)
+        )
       );
     });
-
+  
     setFilteredAdvocates(filteredAdvocates);
   };
-
+  
   const onClick = () => {
     console.log(advocates);
     setFilteredAdvocates(advocates);


### PR DESCRIPTION
Rewrote the search capability to properly search for certain fields. It now searches on `firstName`, `lastName`, `city`, `degree`, and `specialties`.

It also now treats `specialties` as the array that it is, not as a string.

`yearsOfExperience` was removed from the search, since it is a number and not a string, but it will be added back with future improvements.